### PR TITLE
fix id swapping

### DIFF
--- a/generator/generate.awk
+++ b/generator/generate.awk
@@ -804,6 +804,7 @@ END {
             {
                 print "      protected:"
                 print "        b2"type"Id id{};" # Not using `b2_null"type "Id` for simplicity and constexpr-ness, here and everywhere else.
+                print "        void ExchangeId("type"& other) { this->id = std::exchange(other.id, {}); };"
                 print ""
             }
             print "      public:"
@@ -845,7 +846,7 @@ END {
                 print "        explicit "type"(Joint&& other) noexcept"
                 print "        {"
                 print "            if (other.GetType() == "joint_enum_value")"
-                print "                this->id = std::exchange(other.id, {});"
+                print "                ExchangeId(other);"
                 print "            else"
                 print "                BOX2CPP_ASSERT(false && \"This joint is not a `"type"`.\");"
                 print "        }"


### PR DESCRIPTION
Fix for one of the issues in https://github.com/HolyBlackCat/box2cpp/issues/13

![image](https://github.com/user-attachments/assets/aafa312e-4d15-42cc-9c91-6f0d2cd5a43c)
```
protected member "b2::Joint::id" (declared at line 552) is not accessible through a "b2::Joint" pointer or object
```

Maybe the classes don't need to be friends any more either?